### PR TITLE
Docker Quickstart for Hasura JWT

### DIFF
--- a/hasura-jwt-auth.sql
+++ b/hasura-jwt-auth.sql
@@ -37,6 +37,15 @@ begin
 end;
 $$ language 'plpgsql';
 
+
+CREATE TABLE hasura_pgjwt_key (
+   onerow_id bool PRIMARY KEY DEFAULT TRUE
+ , jwt_secret_key text
+ , CONSTRAINT onerow_uni CHECK (onerow_id)
+);
+INSERT INTO hasura_pgjwt_key VALUES (DEFAULT, 'FKlynHJWnKBJaFrB2PgWYX4xvEDY0edcy_HIWCw1AGUpeooHvUg9DfOBSzoeLh2P');
+REVOKE ALL ON hasura_pgjwt_key FROM PUBLIC;
+
 create trigger hasura_user_encrypt_password_trigger
 before insert or update on hasura_user
 for each row execute procedure hasura_user_encrypt_password();
@@ -62,8 +71,8 @@ create or replace function hasura_auth(email in varchar, cleartext_password in v
                     'x-hasura-default-role', default_role,
                     'x-hasura-allowed-roles', allowed_roles
                 )
-            ), current_setting('hasura.jwt_secret_key')) as jwt_token
-    from hasura_user h
+            ), 'hpk.jwt_secret_key') as jwt_token
+    from hasura_user h, hasura_pgjwt_key hpk
     where h.email = hasura_auth.email
     and h.enabled
     and h.crypt_password = hasura_encrypt_password(hasura_auth.cleartext_password, h.crypt_password);

--- a/quickstart/.env
+++ b/quickstart/.env
@@ -1,0 +1,22 @@
+
+# Docker specific configs
+# use only letters and numbers for the project name
+COMPOSE_PROJECT_NAME=hasura-pgjwt-starter-kit
+
+# DB connection details (used by all containers)
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=postgres
+DB_USER=pgadmin
+DB_PASS=password
+
+# PGADMIN connection details
+PGADMIN_EMAIL=pgadmin@localhost.com
+PGADMIN_PASSWORD=mypgadminpassword
+
+# HASURA Parameters
+HASURA_ACCESS_KEY=myaccesskey
+HASURA_ADMIN_SECRET=sA3d3zNrXbtAvtFY9getBcVrA86abxu2vwpDkxzCWvaUTPwj
+HASURA_GRAPHQL_UNAUTHORIZED_ROLE=anonymous
+HASURA_JWT_SECRET_KEY=FKlynHJWnKBJaFrB2PgWYX4xvEDY0edcy_HIWCw1AGUpeooHvUg9DfOBSzoeLh2P
+HASURA_UNAUTHORIZED_ROLE=anonymous

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,0 +1,20 @@
+# Hasura-PGJWT Quickstart
+
+Intent is to allow for a quick and simple production-ready boilerplate from the Hasura PGJWT scripts, with an initial schema defined as code in the SQL files here.
+
+Steps: 
+
+1. (Optional) Change the .env file parameters to something secure
+2. Run `docker-compose up -d --force-recreate` to start with the enviroment defaults. 
+3. Connect to http://localhost:5050 for PGAdmin interface, and http://localhost:8080 for Hasura.
+
+Result:
+
+* A PgAdmin4 instance will be running on port 5050, and can be logged into with the PGADMIN_EMAIL and PGADMIN_PASSWORD specified in the .env file. Note: Use 'postgres', NOT 'localhost' as the hostname in PgAdmin4
+* A Hasura instance will be running on port 8080, and can be accessed using the HASURA_ADMIN_SECRET in the .env file
+* A Postgres database will be running on port 5432, with the username, password and hostname (default postgres) specified in the .env file.
+* The database will have the hasura-jwt-auth service installed and ready to go
+
+
+Note: To connect from PGAdmin4 or Hasura to Postgres, use the docker service name (default 'postgres') as the hostname of the database.
+

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -1,0 +1,42 @@
+    
+version: '3.3'
+services:
+  postgres:
+    image: postgres:latest
+    ports:
+    - "5432:5432"
+    restart: always
+    environment:
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASS}
+      - POSTGRES_DB=${DB_NAME}
+      - JWT_SECRET_KEY=${HASURA_JWT_SECRET_KEY}
+    volumes:
+      - "./pgdb_init:/docker-entrypoint-initdb.d"
+  pgadmin:
+    image: dpage/pgadmin4
+    restart: always
+    depends_on:
+    - postgres
+    ports:
+    - 5050:80
+    ## you can change pgAdmin default username/password with below environment variables
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD}
+  graphql-engine:
+    image: hasura/graphql-engine:latest
+    ports:
+    - "8080:8080"
+    depends_on:
+    - "postgres"
+    restart: always
+    environment:
+      HASURA_GRAPHQL_DATABASE_URL: postgres://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}
+      HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
+      HASURA_GRAPHQL_ACCESS_KEY: ${HASURA_ACCESS_KEY}
+      HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_ADMIN_SECRET}
+      HASURA_GRAPHQL_JWT_SECRET: '{"type":"HS256","key":"${HASURA_JWT_SECRET_KEY}"}'
+      HASURA_GRAPHQL_UNAUTHORIZED_ROLE: ${HASURA_UNAUTHORIZED_ROLE}
+volumes:
+  pgdb_init:

--- a/quickstart/pgdb_init/init.sql
+++ b/quickstart/pgdb_init/init.sql
@@ -1,0 +1,161 @@
+-- Add pgcrypto extension
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+-- This code is from the `pgjwt` extension:
+-- https://github.com/michelp/pgjwt
+-- This code is from the `pgjwt` extension:
+-- https://github.com/michelp/pgjwt
+
+CREATE OR REPLACE FUNCTION url_encode(data bytea) RETURNS text LANGUAGE sql AS $$
+    SELECT translate(encode(data, 'base64'), E'+/=\n', '-_');
+$$;
+
+
+CREATE OR REPLACE FUNCTION url_decode(data text) RETURNS bytea LANGUAGE sql AS $$
+WITH t AS (SELECT translate(data, '-_', '+/') AS trans),
+     rem AS (SELECT length(t.trans) % 4 AS remainder FROM t) -- compute padding size
+    SELECT decode(
+        t.trans ||
+        CASE WHEN rem.remainder > 0
+           THEN repeat('=', (4 - rem.remainder))
+           ELSE '' END,
+    'base64') FROM t, rem;
+$$;
+
+
+CREATE OR REPLACE FUNCTION algorithm_sign(signables text, secret text, algorithm text)
+RETURNS text LANGUAGE sql AS $$
+WITH
+  alg AS (
+    SELECT CASE
+      WHEN algorithm = 'HS256' THEN 'sha256'
+      WHEN algorithm = 'HS384' THEN 'sha384'
+      WHEN algorithm = 'HS512' THEN 'sha512'
+      ELSE '' END AS id)  -- hmac throws error
+SELECT url_encode(hmac(signables, secret, alg.id)) FROM alg;
+$$;
+
+
+CREATE OR REPLACE FUNCTION sign(payload json, secret text, algorithm text DEFAULT 'HS256')
+RETURNS text LANGUAGE sql AS $$
+WITH
+  header AS (
+    SELECT url_encode(convert_to('{"alg":"' || algorithm || '","typ":"JWT"}', 'utf8')) AS data
+    ),
+  payload AS (
+    SELECT url_encode(convert_to(payload::text, 'utf8')) AS data
+    ),
+  signables AS (
+    SELECT header.data || '.' || payload.data AS data FROM header, payload
+    )
+SELECT
+    signables.data || '.' ||
+    algorithm_sign(signables.data, secret, algorithm) FROM signables;
+$$;
+
+
+CREATE OR REPLACE FUNCTION verify(token text, secret text, algorithm text DEFAULT 'HS256')
+RETURNS table(header json, payload json, valid boolean) LANGUAGE sql AS $$
+  SELECT
+    convert_from(url_decode(r[1]), 'utf8')::json AS header,
+    convert_from(url_decode(r[2]), 'utf8')::json AS payload,
+    r[3] = algorithm_sign(r[1] || '.' || r[2], secret, algorithm) AS valid
+  FROM regexp_split_to_array(token, '\.') r;
+$$;
+
+-- add these lines if you execute the script using psql:
+-- \set ON_ERROR_STOP true
+-- set role yourowner;
+-- \connection yourdb
+
+drop table if exists hasura_pgjwt_key;
+CREATE TABLE hasura_pgjwt_key (
+   onerow_id bool PRIMARY KEY DEFAULT TRUE
+ , jwt_secret_key text
+ , CONSTRAINT onerow_uni CHECK (onerow_id)
+);
+INSERT INTO hasura_pgjwt_key VALUES (DEFAULT, 'FKlynHJWnKBJaFrB2PgWYX4xvEDY0edcy_HIWCw1AGUpeooHvUg9DfOBSzoeLh2P');
+REVOKE ALL ON hasura_pgjwt_key FROM PUBLIC;
+
+drop function if exists hasura_auth(varchar, varchar);
+drop trigger if exists hasura_user_encrypt_password_trigger on hasura_user;
+drop function if exists hasura_user_encrypt_password();
+drop function if exists hasura_encrypt_password(text, text);
+drop table if exists hasura_user;
+
+create table hasura_user(
+    user_id serial primary key,
+    email varchar unique,
+    crypt_password varchar,
+    cleartext_password varchar,
+    default_role varchar default 'user',
+    allowed_roles jsonb default '["user"]',
+    enabled boolean default true,
+    jwt_token text
+);
+
+create or replace function hasura_encrypt_password(cleartext_password in text, salt in text) returns varchar as $$
+    select crypt(
+        encode(hmac(cleartext_password,  hasura_pgjwt_key.jwt_secret_key , 'sha256'), 'escape'),
+        salt)
+        FROM hasura_pgjwt_key;
+$$ language sql stable;
+
+create or replace function hasura_user_encrypt_password() returns trigger as $$
+begin
+    if new.cleartext_password is not null and trim(new.cleartext_password) <> '' then
+        new.crypt_password := (hasura_encrypt_password(new.cleartext_password, gen_salt('bf')));
+    end if;
+    new.cleartext_password = null;
+    new.jwt_token = null;
+    return new;
+end;
+$$ language 'plpgsql';
+
+create trigger hasura_user_encrypt_password_trigger
+before insert or update on hasura_user
+for each row execute procedure hasura_user_encrypt_password();
+
+-- https://docs.hasura.io/1.0/graphql/manual/auth/authentication/jwt.html#configuring-jwt-mode
+create or replace function hasura_auth(email in varchar, cleartext_password in varchar) returns setof hasura_user as $$
+    select
+        user_id,
+        email,
+        crypt_password,
+        cleartext_password,
+        default_role,
+        allowed_roles,
+        enabled,
+        sign(
+            json_build_object(
+                'sub', user_id::text,
+                'iss', 'Hasura-JWT-Auth',
+                'iat', round(extract(epoch from now())),
+                'exp', round(extract(epoch from now() + interval '24 hour')),
+                'https://hasura.io/jwt/claims', json_build_object(
+                    'x-hasura-user-id', user_id::text,
+                    'x-hasura-default-role', default_role,
+                    'x-hasura-allowed-roles', allowed_roles
+                )
+            ), 'hpk.jwt_secret_key') as jwt_token
+    from hasura_user h, hasura_pgjwt_key hpk
+    where h.email = hasura_auth.email
+    and h.enabled
+    and h.crypt_password = hasura_encrypt_password(hasura_auth.cleartext_password, h.crypt_password);
+$$ language 'sql' stable;
+
+--  insert an example user and print a jwt_token
+insert into hasura_user(email, cleartext_password) values ('user@example.com', 'password');
+
+do $$ begin
+    raise notice 'Example jwt_token: %s', (select jwt_token from hasura_auth('user@example.com', 'password'));
+end $$;
+CREATE TABLE todos
+(
+    id serial PRIMARY KEY,
+    title text NOT NULL,
+    is_completed boolean NOT NULL DEFAULT false,
+    is_public boolean NOT NULL DEFAULT false,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    user_id text NOT NULL
+);
+


### PR DESCRIPTION
Allows for users to Docker Quickstart with this framework. 

To use: Navigate to the quickstart directory and run `docker-compose up -d` to start a Hasura server with JWT auth installed, and then follow the tables in the Hasura UI